### PR TITLE
Fix links pointing to old repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ We encourage community contributions! You can share your own resources, case stu
 
 > Case studies showcase real-world examples of how UX (User Experience) methods have been successfully applied to address **environmental data** challenges. Your contributions should include a brief overview of the project, the specific UX methods used (e.g., design sprints, user research, prototyping), the outcomes achieved, and any key takeaways for others working on similar projects. Your case studies will inspire and guide others in the field, demonstrating the power of user-centered design.
 
-1. Create a new markdown file in the [co-creation-toolkit/src/content/case-studies/](https://github.com/pautva/co-creation-toolkit/tree/main/src/content/case-studies) folder following [this template](https://github.com/pautva/co-creation-toolkit/blob/main/src/content/templates/case-study.md).
+1. Create a new markdown file in the [co-creation-toolkit/src/content/case-studies/](https://github.com/NERC-EDS/co-creation-toolkit/tree/main/src/content/case-studies) folder following [this template](https://github.com/NERC-EDS/co-creation-toolkit/blob/main/src/content/templates/case-study.md).
 2. Update the case study description at the top of the page
 3. Add content below the '---' line
-4. Add images and other assets to the Case Studies Assets folder (https://github.com/pautva/co-creation-toolkit/tree/main/static/assets/case-studies)
+4. Add images and other assets to the Case Studies Assets folder (https://github.com/NERC-EDS/co-creation-toolkit/tree/main/static/assets/case-studies)
 5. Create a pull request into the main branch
 6. Once the updated files are merged into the `main` branch, the website will be updated
 
@@ -27,7 +27,7 @@ We encourage community contributions! You can share your own resources, case stu
 
 > Toolkit includes templates, guides, and documents that can help others implement effective UX practices in their **environmental data** projects. Think of things like persona templates, interview guides, product requirement documents, usability testing scripts, and any other tools you've found valuable. Your contributions will empower others to gather user insights, design user-friendly solutions, and create impactful environmental data products and services.
 
-1. Create a new markdown file in the [co-creation-toolkit/src/content/toolkit/](https://github.com/pautva/co-creation-toolkit/tree/main/src/content/toolkit) folder following this [template](https://github.com/pautva/co-creation-toolkit/blob/main/src/content/templates/toolkit-method.md).
+1. Create a new markdown file in the [co-creation-toolkit/src/content/toolkit/](https://github.com/NERC-EDS/co-creation-toolkit/tree/main/src/content/toolkit) folder following this [template](https://github.com/NERC-EDS/co-creation-toolkit/blob/main/src/content/templates/toolkit-method.md).
 2. Update the toolkit description at the top of the page
 3. Specify the [category](https://pautva.github.io/co-creation-toolkit/toolkit/) under which the method/tool should be shown in the markdown file: 
     * **User Research**
@@ -35,7 +35,7 @@ We encourage community contributions! You can share your own resources, case stu
     * **Evaluation**
     * **Collaboration**
 4. Add content below the '---' line
-5. Add images and other assets to the Toolkit Assets folder (https://github.com/pautva/co-creation-toolkit/tree/main/static/assets/toolkit)
+5. Add images and other assets to the Toolkit Assets folder (https://github.com/NERC-EDS/co-creation-toolkit/tree/main/static/assets/toolkit)
 6. Create a pull request into the main branch
 7. Once the updated files are merged into the `main` branch, the website will be updated
 

--- a/src/components/CommunityComponent.astro
+++ b/src/components/CommunityComponent.astro
@@ -117,7 +117,7 @@
             <p class="mt-1 dark:text-neutral-400">
               Be part of the EDS Co-Creation Toolkit community! Discuss, ask
               questions, and suggest topics on our <a
-                href="https://github.com/pautva/co-creation-toolkit/discussions"
+                href="https://github.com/NERC-EDS/co-creation-toolkit/discussions"
                 class="hover:underline focus:underline decoration-2"
                 target="_blank">GitHub Discussions page</a
               >.

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -86,7 +86,7 @@
             </button>
             <div id="hs-basic-with-title-and-arrow-stretched-collapse-five" class="hs-accordion-content hidden w-full overflow-hidden transition-[height] duration-300" aria-labelledby="hs-basic-with-title-and-arrow-stretched-heading-five">
               <p class="dark:text-neutral-400">
-                We encourage community contributions! You can share your own resources, case studies, or suggest improvements via our <a href="https://github.com/pautva/co-creation-toolkit" class="text-blue-600">GitHub repository</a>. You can also get in touch with us at <a href="mailto:ux@bgs.ac.uk" class="text-blue-600">ux@bgs.ac.uk</a>
+                We encourage community contributions! You can share your own resources, case studies, or suggest improvements via our <a href="https://github.com/NERC-EDS/co-creation-toolkit" class="text-blue-600">GitHub repository</a>. You can also get in touch with us at <a href="mailto:ux@bgs.ac.uk" class="text-blue-600">ux@bgs.ac.uk</a>
               </p>
             </div>
           </div>

--- a/src/components/GetInvolved.astro
+++ b/src/components/GetInvolved.astro
@@ -99,7 +99,7 @@
     <!-- Icon Block -->
     <a
       class="group flex flex-col justify-center border border-transparent hover:border-black focus:outline-hidden rounded-xl p-4 md:p-7 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-      href="https://github.com/pautva/co-creation-toolkit/discussions"
+      href="https://github.com/NERC-EDS/co-creation-toolkit/discussions"
     >
       <div
         class="flex justify-center items-center size-12 bg-bgs-2 rounded-xl"
@@ -152,7 +152,7 @@
     <!-- Icon Block -->
     <a
       class="group flex flex-col justify-center border border-transparent hover:border-black focus:outline-hidden rounded-xl p-4 md:p-7 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-      href="https://github.com/pautva/co-creation-toolkit"
+      href="https://github.com/NERC-EDS/co-creation-toolkit"
     >
       <div
         class="flex justify-center items-center size-12 bg-bgs-2 rounded-xl"

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -17,7 +17,7 @@ const textLinks: { label: string; href: string }[] = [
 /** Icon links to social media — edit these with links to your profiles! */
 const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[] = [
 	// { label: 'Twitter', href: 'https://twitter.com/me', icon: 'twitter-logo' },
-	{ label: 'GitHub', href: 'https://github.com/pautva/co-creation-toolkit', icon: 'github-logo' },
+	{ label: 'GitHub', href: 'https://github.com/NERC-EDS/co-creation-toolkit', icon: 'github-logo' },
 	// { label: 'dribbble', href: 'https://dribbble.com/me', icon: 'dribbble-logo' },
 	// { label: 'YouTube', href: 'https://www.youtube.com/@me/', icon: 'youtube-logo' },
 ];


### PR DESCRIPTION
Update links pointing to https://github.com/pautva/co-creation-toolkit to point to https://github.com/NERC-EDS/co-creation-toolkit